### PR TITLE
[MOBI-3-프론트-환경-세팅] Fix: React 버전을 자동으로 명시해줍니다.

### DIFF
--- a/packages/config-eslint/next.js
+++ b/packages/config-eslint/next.js
@@ -24,6 +24,9 @@ module.exports = {
       typescript: {
         project
       }
+    },
+    react: {
+      version: 'detect'
     }
   },
   ignorePatterns: [

--- a/packages/config-eslint/react-internal.js
+++ b/packages/config-eslint/react-internal.js
@@ -26,6 +26,9 @@ module.exports = {
       typescript: {
         project
       }
+    },
+    react: {
+      version: 'detect'
     }
   },
   ignorePatterns: [
@@ -37,10 +40,5 @@ module.exports = {
   overrides: [
     // Force ESLint to detect .tsx files
     { files: ['*.js?(x)', '*.ts?(x)'] }
-  ],
-  settings: {
-    react: {
-      version: 'detect'
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## 🌱 작업 개요

<!--작업하신 내용을 간단하게 목록 형식으로 설명해주세요.-->

- 리액트 버전 명시를 하지 않아 생기는 오류를 수정하였습니다.
```shell
academy:lint: Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
lms:lint: Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
storybook:lint: Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
```

## 🧐 중요한 변경 사항

 version을 `detect`로 명시를 해줌으로서 현재 프로젝트 내의 리엑트 버전을 자동적으로 따라가게 해주었습니다.

[참고 문서](https://github.com/jsx-eslint/eslint-plugin-react#configuration)

```ts
  settings: {
   // ...
    react: {
      version: 'detect'
    }
  },
```

<!--스크린샷이 있다면 추가해주세요.-->
<!--공용 컴포넌트, 린트 설정 등에 변경이 있다면 꼭 공유해주세요.-->
